### PR TITLE
Illustrate Scala Issues with Dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,14 @@
 git_repository(
+      name = "io_bazel_rules_scala",
+      remote = "https://github.com/bazelbuild/rules_scala.git",
+      commit = "85308acbd316477f3072e033e7744debcba4f054",
+)
+
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
+
+scala_repositories()
+
+git_repository(
     name = "org_pubref_rules_protobuf",
     remote = "https://github.com/pubref/rules_protobuf",
     tag = "v0.7.1",

--- a/src/main/scala/com/promiseofcake/sample/BUILD
+++ b/src/main/scala/com/promiseofcake/sample/BUILD
@@ -1,0 +1,10 @@
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library", "scala_binary", "scala_test")
+
+scala_binary(
+    name = "sample",
+    srcs = ["ScalaSample.scala"],
+    main_class = "com.promiseofcake.sample.ScalaSample",
+    deps = [
+        "//proto:c",
+    ],
+)

--- a/src/main/scala/com/promiseofcake/sample/ScalaSample.scala
+++ b/src/main/scala/com/promiseofcake/sample/ScalaSample.scala
@@ -1,0 +1,13 @@
+package com.promiseofcake.sample
+
+import com.promiseofcake.proto.c.C
+
+object ScalaSample {
+  def generateC(): C = {
+    C.newBuilder().setId("c").build()
+  }
+
+  def main(args: Array[String]): Unit = {
+    println(generateC().getMessageB.getMessageA.getId)
+  }
+}


### PR DESCRIPTION
When using `java_proto_library` targets from https://github.com/pubref/rules_protobuf @ v.0.7.1

In our `java_binary` target we need only to provide the path to the `//proto:c` dependency for compilation / runtime with `--strict_java_deps=ERROR` enabled. 

For a `scala_binary`, I would expect to only need to do the same, but it seems the output of our `//proto:c` is providing jars in a way that `java_library` will pick them up as exports but `scala_` will not.

Situation is the same as: https://github.com/promiseofcake/bazel-scala-test/pull/2, (Issue: https://github.com/bazelbuild/rules_scala/issues/235) except in this case we don't have control over the target to be able to export all the necessary dependencies.